### PR TITLE
Fixing typos on colors

### DIFF
--- a/src/data/gene_color_pallet.json
+++ b/src/data/gene_color_pallet.json
@@ -336,7 +336,7 @@
 		"name": "SeaFoam2"
 	},
 	"54": {
-		"hex": "3F06137",
+		"hex": "#F06137",
 		"name": "Orange2"
 	},
 	"55": {
@@ -716,7 +716,7 @@
 		"name": "Green7"
 	},
 	"B3": {
-		"hex": "3C46014",
+		"hex": "#C46014",
 		"name": "BurntOrange8"
 	},
 	"B4": {


### PR DESCRIPTION
Some colors had `3` instead of `#` as color code